### PR TITLE
Implement participant profile page and participant self-service routes

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/ParticipantController.java
+++ b/backend/src/main/java/com/example/demo/controller/ParticipantController.java
@@ -2,6 +2,9 @@ package com.example.demo.controller;
 
 import java.util.List;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.http.HttpStatus;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -60,7 +63,34 @@ public class ParticipantController {
     public ResponseEntity<List<Participant>> getAllParticipants() {
         return ResponseEntity.ok(participantService.getAllParticipants());
     }
+    
+    //methods for front end use case
+    @PreAuthorize("hasRole('PARTICIPANT')")
+    @GetMapping("/me")
+    public ResponseEntity<Participant> getMyParticipant(Authentication authentication) {
+        Participant participant = participantService.getMyParticipant(authentication.getName());
+        return ResponseEntity.ok(participant);
+    }
 
+    @PreAuthorize("hasRole('PARTICIPANT')")
+    @PostMapping("/me")
+    public ResponseEntity<Participant> createMyParticipant(
+            Authentication authentication,
+            @Valid @RequestBody Participant participant) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(participantService.createMyParticipant(authentication.getName(), participant));
+    }
+
+    @PreAuthorize("hasRole('PARTICIPANT')")
+    @PutMapping("/me")
+    public ResponseEntity<Participant> updateMyParticipant(
+            Authentication authentication,
+            @RequestBody Participant updatedParticipant) {
+        return ResponseEntity.ok(
+                participantService.updateMyParticipant(authentication.getName(), updatedParticipant)
+        );
+    }
+    
     /**
      * Retrieves a participant by their ID.
      * 

--- a/backend/src/main/java/com/example/demo/repository/ParticipantRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/ParticipantRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface ParticipantRepository extends JpaRepository<Participant, Long>{
     boolean existsByEmail(String email);
     Optional<Participant> findByEmail(String email);
+    Optional<Participant> findByUserUsername(String username);
 }

--- a/backend/src/main/java/com/example/demo/service/ParticipantService.java
+++ b/backend/src/main/java/com/example/demo/service/ParticipantService.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.example.demo.entity.User;
+import com.example.demo.repository.UserRepository;
 import com.example.demo.entity.Participant;
 import com.example.demo.repository.ParticipantRepository;
 
@@ -13,9 +15,72 @@ import com.example.demo.repository.ParticipantRepository;
 public class ParticipantService {
 
     private final ParticipantRepository participantRepository;
+    private final UserRepository userRepository;
 
-    public ParticipantService(ParticipantRepository participantRepository) {
+    public ParticipantService(
+            ParticipantRepository participantRepository,
+            UserRepository userRepository) {
         this.participantRepository = participantRepository;
+        this.userRepository = userRepository;
+    }
+
+    public Participant getMyParticipant(String username) {
+        return participantRepository.findByUserUsername(username)
+            .orElseThrow(() -> new ResponseStatusException(
+                HttpStatus.NOT_FOUND,
+                "Participant profile not found for current user"
+            ));
+    }
+
+    public Participant createMyParticipant(String username, Participant participant) {
+        User user = userRepository.findByUsername(username)
+            .orElseThrow(() -> new ResponseStatusException(
+                HttpStatus.NOT_FOUND,
+                "User not found"
+            ));
+
+        if (user.getParticipant() != null) {
+            throw new ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "Participant profile already exists for this user"
+            );
+        }
+
+        if (participantRepository.existsByEmail(participant.getEmail())) {
+            throw new ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "A participant with this email already exists"
+            );
+        }
+
+        Participant newParticipant = Participant.createParticipant(
+            participant.getFirstName(),
+            participant.getLastName(),
+            participant.getEmail(),
+            participant.getPhone(),
+            participant.getRole()
+        );
+
+        newParticipant.setUser(user);
+        user.setParticipant(newParticipant);
+
+        return participantRepository.save(newParticipant);
+    }
+
+    public Participant updateMyParticipant(String username, Participant updatedParticipant) {
+        Participant existingParticipant = participantRepository.findByUserUsername(username)
+            .orElseThrow(() -> new ResponseStatusException(
+                HttpStatus.NOT_FOUND,
+                "Participant profile not found for current user"
+            ));
+
+        existingParticipant.setFirstName(updatedParticipant.getFirstName());
+        existingParticipant.setLastName(updatedParticipant.getLastName());
+        existingParticipant.setEmail(updatedParticipant.getEmail());
+        existingParticipant.setPhone(updatedParticipant.getPhone());
+        existingParticipant.setRole(updatedParticipant.getRole());
+
+        return participantRepository.save(existingParticipant);
     }
 
     public Participant createParticipant(Participant participant) {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1303,6 +1303,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -1330,6 +1339,20 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2390,11 +2413,41 @@
         "node": ">=12"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/memoize-one": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/minimatch": {
       "version": "3.1.5",

--- a/frontend/src/pages/Participants/ParticipantsPage.jsx
+++ b/frontend/src/pages/Participants/ParticipantsPage.jsx
@@ -1,8 +1,376 @@
+import { useEffect, useMemo, useState } from "react";
+import "../AdminManagement/AdminManagement.css";
+
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || "http://localhost:8080";
+
+const participantRoleOptions = ["ATTENDEE", "SPEAKER", "STAFF"];
+
+const emptyParticipantForm = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  phone: "",
+  role: "ATTENDEE",
+};
+
 export default function ParticipantsPage() {
+  const token = localStorage.getItem("token");
+
+  const [participant, setParticipant] = useState(null);
+  const [participants, setParticipants] = useState([]);
+  const [form, setForm] = useState(emptyParticipantForm);
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  function parseJwt(tokenValue) {
+    try {
+      if (!tokenValue) return null;
+      const payload = tokenValue.split(".")[1];
+      return JSON.parse(atob(payload));
+    } catch {
+      return null;
+    }
+  }
+
+  const jwtPayload = useMemo(() => parseJwt(token), [token]);
+
+  const role =
+    jwtPayload?.role ||
+    jwtPayload?.authorities ||
+    jwtPayload?.userRole ||
+    null;
+
+  const username =
+    jwtPayload?.sub ||
+    jwtPayload?.username ||
+    jwtPayload?.userName ||
+    "User";
+
+  const isParticipant = role === "PARTICIPANT";
+  const canViewParticipants =
+    role === "ADMIN" || role === "ORGANIZER" || role === "STAFF";
+
+  useEffect(() => {
+    async function loadPage() {
+      try {
+        setLoading(true);
+        setError("");
+        setMessage("");
+
+        if (!token) {
+          throw new Error("No authentication token found.");
+        }
+
+        if (isParticipant) {
+          await loadMyParticipant();
+        } else if (canViewParticipants) {
+          await loadParticipants();
+        } else {
+          throw new Error("You do not have permission to view this page.");
+        }
+      } catch (err) {
+        setError(err.message || "Failed to load participants page.");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadPage();
+  }, [token, role]);
+
+  async function loadMyParticipant() {
+    const response = await fetch(`${API_BASE_URL}/participants/me`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (response.status === 404) {
+      setParticipant(null);
+      setForm(emptyParticipantForm);
+      return;
+    }
+
+    if (!response.ok) {
+      throw new Error("Failed to load your participant profile.");
+    }
+
+    const data = await response.json();
+
+    setParticipant(data);
+    setForm({
+      firstName: data.firstName || "",
+      lastName: data.lastName || "",
+      email: data.email || "",
+      phone: data.phone || "",
+      role: data.role || "ATTENDEE",
+    });
+  }
+
+  async function loadParticipants() {
+    const response = await fetch(`${API_BASE_URL}/participants`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to load participants.");
+    }
+
+    const data = await response.json();
+    setParticipants(data ?? []);
+  }
+
+  function handleFieldChange(field, value) {
+    setForm((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+
+    try {
+      setSaving(true);
+      setError("");
+      setMessage("");
+
+      const isUpdating = Boolean(participant?.participantId);
+
+      const response = await fetch(`${API_BASE_URL}/participants/me`, {
+        method: isUpdating ? "PUT" : "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(form),
+      });
+
+      const data = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        throw new Error(
+          data?.message ||
+            data?.error ||
+            "Failed to save participant profile."
+        );
+      }
+
+      setParticipant(data);
+      setForm({
+        firstName: data.firstName || "",
+        lastName: data.lastName || "",
+        email: data.email || "",
+        phone: data.phone || "",
+        role: data.role || "ATTENDEE",
+      });
+
+      setMessage(
+        isUpdating
+          ? "Participant profile updated successfully."
+          : "Participant profile created successfully."
+      );
+    } catch (err) {
+      setError(err.message || "Error saving participant profile.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function getRoleBadgeClass(participantRole) {
+    switch (participantRole) {
+      case "STAFF":
+        return "staff-role";
+      case "SPEAKER":
+        return "organizer-role";
+      case "ATTENDEE":
+      default:
+        return "participant-role";
+    }
+  }
+
+  if (loading) {
+    return <p className="admin-muted">Loading participants...</p>;
+  }
+
   return (
-    <div className="content-card">
-      <h2>Participants</h2>
-      <p>This page will contain the CRUD interface for participants.</p>
+    <div className="admin-page">
+      <h1 className="admin-page-title">Participants</h1>
+
+      {isParticipant && (
+        <p className="admin-page-subtitle">
+          Welcome, {username}. Finish creating your participant profile or update
+          your information.
+        </p>
+      )}
+
+      {canViewParticipants && (
+        <p className="admin-page-subtitle">
+          View participant information stored in the system.
+        </p>
+      )}
+
+      {message && <div className="admin-message success">{message}</div>}
+      {error && <div className="admin-message error">{error}</div>}
+
+      {isParticipant && (
+        <section className="admin-section">
+          <h2 className="admin-section-title">
+            {participant ? "Edit Participant Profile" : "Finish Creating Account"}
+          </h2>
+
+          <p className="admin-section-subtitle">
+            This creates or updates your participant entity in the database.
+          </p>
+
+          <form className="admin-form" onSubmit={handleSubmit}>
+            <div className="admin-form-grid">
+              <div className="admin-form-group">
+                <label className="admin-label">First Name</label>
+                <input
+                  className="admin-input"
+                  type="text"
+                  value={form.firstName}
+                  onChange={(e) =>
+                    handleFieldChange("firstName", e.target.value)
+                  }
+                  required
+                />
+              </div>
+
+              <div className="admin-form-group">
+                <label className="admin-label">Last Name</label>
+                <input
+                  className="admin-input"
+                  type="text"
+                  value={form.lastName}
+                  onChange={(e) =>
+                    handleFieldChange("lastName", e.target.value)
+                  }
+                  required
+                />
+              </div>
+
+              <div className="admin-form-group">
+                <label className="admin-label">Email</label>
+                <input
+                  className="admin-input"
+                  type="email"
+                  value={form.email}
+                  onChange={(e) => handleFieldChange("email", e.target.value)}
+                  required
+                />
+              </div>
+
+              <div className="admin-form-group">
+                <label className="admin-label">Phone</label>
+                <input
+                  className="admin-input"
+                  type="text"
+                  value={form.phone}
+                  onChange={(e) => handleFieldChange("phone", e.target.value)}
+                />
+              </div>
+
+              <div className="admin-form-group">
+                <label className="admin-label">Requested Role</label>
+                <select
+                  className="admin-select"
+                  value={form.role}
+                  onChange={(e) => handleFieldChange("role", e.target.value)}
+                >
+                  {participantRoleOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="admin-actions-row">
+              <button
+                className="admin-btn admin-btn-primary"
+                type="submit"
+                disabled={saving}
+              >
+                {saving
+                  ? "Saving..."
+                  : participant
+                    ? "Update Profile"
+                    : "Create Profile"}
+              </button>
+            </div>
+          </form>
+        </section>
+      )}
+
+      {canViewParticipants && (
+        <section className="admin-section">
+          <h2 className="admin-section-title">Participant Records</h2>
+          <p className="admin-section-subtitle">
+            Admins, organizers, and staff can view participant information.
+          </p>
+
+          <div className="admin-table-wrapper">
+            <table className="admin-table">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Name</th>
+                  <th>Email</th>
+                  <th>Phone</th>
+                  <th>Role</th>
+                  <th>Active</th>
+                </tr>
+              </thead>
+
+              <tbody>
+                {participants.length === 0 ? (
+                  <tr>
+                    <td colSpan="6" className="admin-empty">
+                      No participants found.
+                    </td>
+                  </tr>
+                ) : (
+                  participants.map((p) => (
+                    <tr key={p.participantId}>
+                      <td>{p.participantId}</td>
+                      <td>
+                        {p.firstName} {p.lastName}
+                      </td>
+                      <td>{p.email}</td>
+                      <td>{p.phone || "N/A"}</td>
+                      <td>
+                        <span
+                          className={`admin-badge ${getRoleBadgeClass(p.role)}`}
+                        >
+                          {p.role}
+                        </span>
+                      </td>
+                      <td>
+                        <span
+                          className={`admin-badge ${
+                            p.active ? "enabled" : "disabled"
+                          }`}
+                        >
+                          {p.active ? "Active" : "Inactive"}
+                        </span>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Implemented the participant self-service profile flow for the Participants page.

On the backend, I added participant-owned /participants/me endpoints so logged-in users with the PARTICIPANT role can create, view, and update their own participant profile instead of relying on admin-only routes. This included updating ParticipantController, adding findByUserUsername() in ParticipantRepository, and expanding ParticipantService to connect the logged-in User entity to their Participant entity using UserRepository.

On the frontend, I made ParticipantsPage.jsx so participants can finish creating their account, request a participant role (ATTENDEE, SPEAKER, or STAFF), and update their information later. Admins, organizers, and staff can still view participant records in a table, while admins can confirm the created participant appears in the system.

frontend dependencies updated package-lock.json after running npm install so I don't know if that was good or bad